### PR TITLE
Actualiza cómo correr el tablero porque ya no existe la carpeta 'templates'

### DIFF
--- a/src/run_docker.sh
+++ b/src/run_docker.sh
@@ -3,6 +3,6 @@
 # Corre los contenedores de Docker del servidor islasgeci.org
 docker run --detach --publish 251:80    --rm --volume ${HOME}/repositorios/gatos-trampas:/go/src/bitbucket.org/IslasGECI/gatos-trampas gatos-trampas ./mapa-gatos
 docker run --detach --publish 500:5000  --rm --volume ${HOME}/repositorios/tablero_api/:/workdir   islasgeci/tablero_api
-docker run --detach --publish 5000:80   --rm --volume ${HOME}/repositorios/tablero_front/templates:/usr/local/apache2/htdocs/ islasgeci/tablero_front
+docker run --detach --publish 5000:80   --rm islasgeci/tablero_front
 docker run --detach --publish 8080:8888 --rm --volume ${HOME}/nerd-notebooks/:/workdir             islasgeci/jupyter:3691
 docker run --detach --publish 8888:8888 --rm --volume ${HOME}/notebooks/:/workdir                  islasgeci/jupyter:3691


### PR DESCRIPTION
Esto este cambio permite que diariamente se eche a andar el tablero